### PR TITLE
fix VerifyChapPasswd for Python 3.5.2

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -605,13 +605,14 @@ class AuthPacket(Packet):
             return False
 
         chapid = chap_password[0]
+        if six.PY3:
+            chapid = chr(chapid).encode('utf-8')
         password = chap_password[1:]
 
         challenge = self.authenticator
         if 'CHAP-Challenge' in self:
             challenge = self['CHAP-Challenge'][0]
-
-        return password == md5_constructor(b"%s%s%s" % (chr(chapid).encode('utf-8'), userpwd, challenge)).digest()
+        return password == md5_constructor(b'%s%s%s' % (chapid, userpwd, challenge)).digest()
 
     def VerifyAuthRequest(self):
         """Verify request authenticator.

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -611,7 +611,7 @@ class AuthPacket(Packet):
         if 'CHAP-Challenge' in self:
             challenge = self['CHAP-Challenge'][0]
 
-        return password == md5_constructor("%s%s%s" % (chapid, userpwd, challenge)).digest()
+        return password == md5_constructor(b"%s%s%s" % (chr(chapid).encode('utf-8'), userpwd, challenge)).digest()
 
     def VerifyAuthRequest(self):
         """Verify request authenticator.

--- a/pyrad/tests/data/chap
+++ b/pyrad/tests/data/chap
@@ -1,0 +1,6 @@
+# A simple dictionary
+
+ATTRIBUTE  User-Name         1       string
+ATTRIBUTE  User-Password     2       string encrypt=1
+ATTRIBUTE  CHAP-Password     3       octets
+ATTRIBUTE  CHAP-Challenge    60      octets


### PR DESCRIPTION
The old code causes an error with Python 3.5.2

```
    File "/path_to_module/server.py", line 269, in VerifyChapPasswd
        return password == hashlib.md5("%s%s%s" % (chapid, userpwd, challenge)).digest()
TypeError: Unicode-objects must be encoded before hashing
```
