### PR TITLE
Fixed packet get() method to call __getitem__ explicitly (encode)

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -185,6 +185,9 @@ class Packet(dict):
 
         encoded.extend(value)
 
+    def get(self, key, failobj=None):
+        return self.__getitem__(key) or failobj
+
     def __getitem__(self, key):
         if not isinstance(key, six.string_types):
             return dict.__getitem__(self, key)


### PR DESCRIPTION
Packet object is inherited from the dict class and when you try to access data by encoded int key - it works.
But if you try to access to the data by unencoded key name - it returns `None`.
```
>>reply['Callback-Number'] == reply.get('Callback-Number')  # False
>>reply[19] == reply.get(19)  # True
```
Looks like it was broken after the change of the base Packet parent `Userdict --> dict` since v1.1.
Because the original dict uses encoded keys, therefore `get()` can not find by the original
unencoded. There is much more magic with dicts since original get() will not call __getitem__().