### PR TITLE
Change version sourcing

### DIFF
--- a/pyrad/__init__.py
+++ b/pyrad/__init__.py
@@ -41,5 +41,6 @@ __docformat__ = 'epytext en'
 __author__ = 'Wichert Akkerman <wichert@wiggy.net>'
 __url__ = 'http://www.wiggy.net/code/pyrad.xhtml'
 __copyright__ = 'Copyright 2002-2007 Wichert Akkerman'
+__version__ = '2.1'
 
 __all__ = ['client', 'dictionary', 'packet', 'server', 'tools', 'dictfile']

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from setuptools import setup, find_packages
 
-
-version = '2.1'
-
+import pyrad
 
 setup(name='pyrad',
-      version=version,
+      version=pyrad.__version__,
       author='Wichert Akkerman',
       author_email='wichert@wiggy.net',
       url='https://github.com/wichert/pyrad',
@@ -15,15 +13,15 @@ setup(name='pyrad',
       description='RADIUS tools',
       long_description=open('README.rst').read(),
       classifiers=[
-       'Development Status :: 6 - Mature',
-       'Intended Audience :: Developers',
-       'License :: OSI Approved :: BSD License',
-       'Programming Language :: Python :: 2.7',
-       'Programming Language :: Python :: 3.2',
-       'Programming Language :: Python :: 3.6',
-       'Topic :: Software Development :: Libraries :: Python Modules',
-       'Topic :: System :: Systems Administration :: Authentication/Directory',
-       ],
+          'Development Status :: 6 - Mature',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: BSD License',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.2',
+          'Programming Language :: Python :: 3.6',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+          'Topic :: System :: Systems Administration :: Authentication/Directory',
+      ],
       packages=find_packages(exclude=['tests']),
       keywords=['radius', 'authentication'],
       zip_safe=True,


### PR DESCRIPTION
Change the package version single-sourcing in order to allow getting the version with `package.__version__`, which is arguably the most common way.

Also, setting the version in `setup.py` makes it unavailable for editable installations.