### PR TITLE
Fixing default host (0.0.0.0) asignment

### DIFF
--- a/pyrad/server_async.py
+++ b/pyrad/server_async.py
@@ -58,7 +58,7 @@ class DatagramProtocolServer(asyncio.Protocol):
         if addr[0] in self.hosts:
             remote_host = self.hosts[addr[0]]
         elif '0.0.0.0' in self.hosts:
-            remote_host = self.hosts['0.0.0.0'].secret
+            remote_host = self.hosts['0.0.0.0']
         else:
             self.logger.warn('[%s:%d] Drop package from unknown source %s', self.ip, self.port, addr)
             return


### PR DESCRIPTION
In the original source code, when there isn't a remote host that matches with the source ip address but a default host is defined (0.0.0.0) it's not working because the assigment is not correct.

Thanks for your project.