### PR TITLE
Issue: 119 - convert string to integer in other than dec cases.

### DIFF
--- a/pyrad/dictionary.py
+++ b/pyrad/dictionary.py
@@ -220,6 +220,18 @@ class Dictionary(object):
         (attribute, code, datatype) = tokens[1:4]
 
         codes = code.split('.')
+
+        # Codes can be sent as hex, or octal or decimal string representations.
+        tmp = []
+        for c in codes:
+          if c.startswith('0x'):
+            tmp.append(int(c, 16))
+          elif c.startswith('0o'):
+            tmp.append(int(c, 8))
+          else:
+            tmp.append(int(c, 10))
+        codes = tmp
+
         is_sub_attribute = (len(codes) > 1)
         if len(codes) == 2:
             code = int(codes[1])

--- a/pyrad/tests/data/simple
+++ b/pyrad/tests/data/simple
@@ -12,3 +12,5 @@ ATTRIBUTE  Test-Tlv          9       tlv
 ATTRIBUTE  Test-Tlv-Str      9.1     string
 ATTRIBUTE  Test-Tlv-Int      9.2     integer
 ATTRIBUTE  Test-Integer64    10      integer64
+ATTRIBUTE  Test-Integer64-Hex    0x0a      integer64
+ATTRIBUTE  Test-Integer64-Oct    0o12      integer64

--- a/pyrad/tests/testDictionary.py
+++ b/pyrad/tests/testDictionary.py
@@ -69,7 +69,7 @@ class DictionaryParsingTests(unittest.TestCase):
     simple_dict_values = [
         ('Test-String', 1, 'string'),
         ('Test-Octets', 2, 'octets'),
-        ('Test-Integer', 3, 'integer'),
+        ('Test-Integer', 0x03, 'integer'),
         ('Test-Ip-Address', 4, 'ipaddr'),
         ('Test-Ipv6-Address', 5, 'ipv6addr'),
         ('Test-If-Id', 6, 'ifid'),
@@ -78,7 +78,9 @@ class DictionaryParsingTests(unittest.TestCase):
         ('Test-Tlv', 9, 'tlv'),
         ('Test-Tlv-Str', 1, 'string'),
         ('Test-Tlv-Int', 2, 'integer'),
-        ('Test-Integer64', 10, 'integer64')
+        ('Test-Integer64', 10, 'integer64'),
+        ('Test-Integer64-Hex', 10, 'integer64'),
+        ('Test-Integer64-Oct', 10, 'integer64'),
     ]
 
     def setUp(self):


### PR DESCRIPTION
pyrad's conversion (blindly) of strings to integers is problematic.
Catch cases of hexdecimal and octal strings, since these are easy
to catch :) (and were the source of a problem for me)