### PR TITLE
Fixed packet get() method to not throw KeyError when accessing the non-existing key

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -293,7 +293,11 @@ class Packet(OrderedDict):
         encoded.extend(value)
 
     def get(self, key, failobj=None):
-        return self.__getitem__(key) or failobj
+        try:
+            res = self.__getitem__(key)
+        except KeyError:
+            res = failobj
+        return res
 
     def __getitem__(self, key):
         if not isinstance(key, six.string_types):


### PR DESCRIPTION
RADIUS servers can send not full replies, e.g `Reply-Message` could be missing in the actual reply.
We should make `def get()` to behave more similar to the python dict `def get()`, so it will not throw a KeyError if the key is missing in the reply:
```
>>>reply['Reply-Message']  # threw an error
>>>reply.get('Reply-Message')  # return None or failobj if the key is missing
```