### PR TITLE
Fixed getting packet value by int key.

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -300,11 +300,18 @@ class Packet(OrderedDict):
         return res
 
     def __getitem__(self, key):
-        if not isinstance(key, six.string_types):
+        key_name, key_number = None, None
+        if isinstance(key, six.string_types):
+            key_name = key
+            key_number = self._EncodeKey(key)
+        elif isinstance(key, six.integer_types):
+            key_name = self._DecodeKey(key)
+            key_number = key
+        if not key_name or not key_number:
             return OrderedDict.__getitem__(self, key)
 
-        values = OrderedDict.__getitem__(self, self._EncodeKey(key))
-        attr = self.dict.attributes[key]
+        values = OrderedDict.__getitem__(self, key_number)
+        attr = self.dict.attributes[key_name]
         if attr.type == 'tlv':  # return map from sub attribute code to its values
             res = {}
             for (sub_attr_key, sub_attr_val) in values.items():


### PR DESCRIPTION
There is a difference in getting packet text value by the text key and int key from the radius.dictionary mapping:
>>>reply['Callback-Number']
...['11FFF']
>>>reply[19]
...[b'11FFF']

Replies are not of the same type and this could lead to issues when using them for string concatenation: 'Reply: ' + reply[19] will give an error since we want to concat str and bytes.