### PR TITLE
Fixup packet SaltCrypt

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -578,7 +578,7 @@ class Packet(OrderedDict):
         random_value = 32768 + random_generator.randrange(0, 32767)
         if six.PY3:
             salt_raw = struct.pack('!H', random_value )
-            salt = chr(salt_raw[0]) + chr(salt_raw[0])
+            salt = chr(salt_raw[0]) + chr(salt_raw[1])
         else:
             salt = struct.pack('!H', random_value )
             salt = chr(ord(salt[0]) | 1 << 7)+salt[1]

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -6,7 +6,12 @@
 
 from collections import OrderedDict
 import struct
-import random
+try:
+    import secrets
+    random_generator = secrets.SystemRandom()
+except ImportError:
+    import random
+    random_generator = random.SystemRandom()
 import hmac
 try:
     import hashlib
@@ -33,9 +38,6 @@ DisconnectNAK = 42
 CoARequest = 43
 CoAACK = 44
 CoANAK = 45
-
-# Use cryptographic-safe random generator as provided by the OS.
-random_generator = random.SystemRandom()
 
 # Current ID
 CurrentID = random_generator.randrange(1, 255)

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -590,7 +590,7 @@ class Packet(OrderedDict):
         if len(buf) % 16 != 0:
             buf += six.b('\x00') * (16 - (len(buf) % 16))
 
-        last = self.authenticator + salt
+        last = self.authenticator + six.b(salt)
         while buf:
             hash = md5_constructor(self.secret + last).digest()
             if six.PY3:


### PR DESCRIPTION
Several bugs, two specific to python3 and one in general.  Pre-this, hostapd can't decode Tunnel-Password. Post-this, it can. The secrets change is unnecessary, but seemed like the Right Thing to Do.