### PR TITLE
Authenticator issue in AuthPacket

### DIFF
--- a/pyrad/client_async.py
+++ b/pyrad/client_async.py
@@ -135,7 +135,7 @@ class DatagramProtocolClient(asyncio.Protocol):
                 else:
                     self.logger.warn('[%s:%d] Ignore invalid reply for id %d. %s', self.server, self.port, reply.id)
             else:
-                self.logger.warn('[%s:%d] Ignore invalid reply: %d', self.server, self.port, data)
+                self.logger.warn('[%s:%d] Ignore invalid reply: %s', self.server, self.port, data)
 
         except Exception as exc:
             self.logger.error('[%s:%d] Error on decode packet: %s', self.server, self.port, exc)

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -651,6 +651,9 @@ class AuthPacket(Packet):
         if self.id is None:
             self.id = self.CreateID()
 
+        if self.message_authenticator:
+            self._refresh_message_authenticator()
+
         attr = self._PktEncodeAttributes()
         if self.auth_type == 'eap-md5':
             header = struct.pack(
@@ -667,9 +670,6 @@ class AuthPacket(Packet):
                 + attr
                 + struct.pack('!BB16s', 80, struct.calcsize('!BB16s'), digest)
             )
-
-        if self.message_authenticator:
-            self._refresh_message_authenticator()
 
         header = struct.pack('!BBH16s', self.code, self.id,
                              (20 + len(attr)), self.authenticator)


### PR DESCRIPTION
Authenticator attribute must be refreshed before encoding the attributes. If not, the first packet is sent with attribute 80 set to 0. Retransmits are good since the authenticator attribute is refreshed just before the packet is sent.

A second patch to fix a type error in logger in ClientAsync in case of an invalid reply.

Thank you!