### PR TITLE
Fix bug causing Message-Authenticator verification to fail if multiple instances of an attribute do not appear sequentially in the attributes list

### DIFF
--- a/pyrad/tests/data/full
+++ b/pyrad/tests/data/full
@@ -14,6 +14,8 @@ ATTRIBUTE  Test-Tlv       4     tlv
 ATTRIBUTE  Test-Tlv-Str   4.1   string
 ATTRIBUTE  Test-Tlv-Int   4.2   integer
 
+ATTRIBUTE  Message-Authenticator 80  octets
+
 VENDOR Simplon 16
 
 


### PR DESCRIPTION
What the title says. This is essentially the same bug as in #140 but for Message-Authenticator instead. I looked through packet.py and I _think_ this was the only other place affected by that type of bug. 