### PR TITLE
Fix documentation for BindToAddress

### DIFF
--- a/pyrad/server.py
+++ b/pyrad/server.py
@@ -125,8 +125,8 @@ class Server(host.Host):
 
 
     def BindToAddress(self, addr):
-        """Add an address to listen to.
-        An empty string indicated you want to listen on all addresses.
+        """Add an address to listen on a specific interface.
+        String "0.0.0.0" indicates you want to listen on all interfaces.
 
         :param addr: IP address to listen on
         :type  addr: string


### PR DESCRIPTION
Due to commit 5b382066c49000b9336d58547af01d031ab37b73, when you pass an empty string to `BindToAddress()` it doesn't bind to socket anymore and "0.0.0.0" needs to be passed instead. The description for the function is outdated and can cause a lot of headaches.