### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tests/testBidict.py
+++ b/tests/testBidict.py
@@ -52,5 +52,5 @@ class BiDictTests(unittest.TestCase):
         self.bidict.Add("shake", "vanilla")
         self.bidict.Add("pie", "custard")
         self.assertRaises(KeyError, operator.getitem, self.bidict, "missing")
-        self.assertEquals(self.bidict["shake"], "vanilla")
-        self.assertEquals(self.bidict["pie"], "custard")
+        self.assertEqual(self.bidict["shake"], "vanilla")
+        self.assertEqual(self.bidict["pie"], "custard")

--- a/tests/testClient.py
+++ b/tests/testClient.py
@@ -22,33 +22,33 @@ class ConstructionTests(unittest.TestCase):
 
     def testSimpleConstruction(self):
         client = Client(self.server)
-        self.failUnless(client.server is self.server)
+        self.assertTrue(client.server is self.server)
         self.assertEqual(client.authport, 1812)
         self.assertEqual(client.acctport, 1813)
         self.assertEqual(client.secret, six.b(''))
         self.assertEqual(client.retries, 3)
         self.assertEqual(client.timeout, 5)
-        self.failUnless(client.dict is None)
+        self.assertTrue(client.dict is None)
 
     def testParameterOrder(self):
         marker = object()
         client = Client(self.server, 123, 456, 789, "secret", marker)
-        self.failUnless(client.server is self.server)
+        self.assertTrue(client.server is self.server)
         self.assertEqual(client.authport, 123)
         self.assertEqual(client.acctport, 456)
         self.assertEqual(client.coaport, 789)
         self.assertEqual(client.secret, "secret")
-        self.failUnless(client.dict is marker)
+        self.assertTrue(client.dict is marker)
 
     def testNamedParameters(self):
         marker = object()
         client = Client(server=self.server, authport=123, acctport=456,
                       secret="secret", dict=marker)
-        self.failUnless(client.server is self.server)
+        self.assertTrue(client.server is self.server)
         self.assertEqual(client.authport, 123)
         self.assertEqual(client.acctport, 456)
         self.assertEqual(client.secret, "secret")
-        self.failUnless(client.dict is marker)
+        self.assertTrue(client.dict is marker)
 
 
 class SocketTests(unittest.TestCase):
@@ -66,7 +66,7 @@ class SocketTests(unittest.TestCase):
         self.client._SocketOpen()
         sock = self.client._socket
         self.client._SocketOpen()
-        self.failUnless(sock is self.client._socket)
+        self.assertTrue(sock is self.client._socket)
 
     def testBind(self):
         self.client.bind((BIND_IP, BIND_PORT))
@@ -123,7 +123,7 @@ class SocketTests(unittest.TestCase):
         self.client.timeout = 1
         packet = MockPacket(AccessRequest)
         self.assertRaises(Timeout, self.client._SendPacket, packet, 432)
-        self.failIf("Acct-Delay-Time" in packet)
+        self.assertFalse("Acct-Delay-Time" in packet)
 
     def testSingleAccountDelay(self):
         self.client.retries = 2
@@ -154,7 +154,7 @@ class SocketTests(unittest.TestCase):
         MockPoll.results = [(1, select.POLLIN)]
         packet = MockPacket(AccountingRequest, verify=True)
         reply = self.client._SendPacket(packet, 432)
-        self.failUnless(reply is packet.reply)
+        self.assertTrue(reply is packet.reply)
 
     def testInvalidReply(self):
         self.client.retries = 1
@@ -172,14 +172,14 @@ class OtherTests(unittest.TestCase):
 
     def testCreateAuthPacket(self):
         packet = self.client.CreateAuthPacket(id=15)
-        self.failUnless(isinstance(packet, AuthPacket))
-        self.failUnless(packet.dict is self.client.dict)
+        self.assertTrue(isinstance(packet, AuthPacket))
+        self.assertTrue(packet.dict is self.client.dict)
         self.assertEqual(packet.id, 15)
         self.assertEqual(packet.secret, six.b('zeer geheim'))
 
     def testCreateAcctPacket(self):
         packet = self.client.CreateAcctPacket(id=15)
-        self.failUnless(isinstance(packet, AcctPacket))
-        self.failUnless(packet.dict is self.client.dict)
+        self.assertTrue(isinstance(packet, AcctPacket))
+        self.assertTrue(packet.dict is self.client.dict)
         self.assertEqual(packet.id, 15)
         self.assertEqual(packet.secret, six.b('zeer geheim'))

--- a/tests/testHost.py
+++ b/tests/testHost.py
@@ -32,20 +32,20 @@ class PacketCreationTests(unittest.TestCase):
 
     def testCreatePacket(self):
         packet = self.host.CreatePacket(id=15)
-        self.failUnless(isinstance(packet, Packet))
-        self.failUnless(packet.dict is self.host.dict)
+        self.assertTrue(isinstance(packet, Packet))
+        self.assertTrue(packet.dict is self.host.dict)
         self.assertEqual(packet.id, 15)
 
     def testCreateAuthPacket(self):
         packet = self.host.CreateAuthPacket(id=15)
-        self.failUnless(isinstance(packet, AuthPacket))
-        self.failUnless(packet.dict is self.host.dict)
+        self.assertTrue(isinstance(packet, AuthPacket))
+        self.assertTrue(packet.dict is self.host.dict)
         self.assertEqual(packet.id, 15)
 
     def testCreateAcctPacket(self):
         packet = self.host.CreateAcctPacket(id=15)
-        self.failUnless(isinstance(packet, AcctPacket))
-        self.failUnless(packet.dict is self.host.dict)
+        self.assertTrue(isinstance(packet, AcctPacket))
+        self.assertTrue(packet.dict is self.host.dict)
         self.assertEqual(packet.id, 15)
 
 
@@ -78,10 +78,10 @@ class PacketSendTest(unittest.TestCase):
 
     def testSendPacket(self):
         self.host.SendPacket(self.fd, self.packet)
-        self.failUnless(self.fd.data is self.packet.packet)
-        self.failUnless(self.fd.target is self.packet.source)
+        self.assertTrue(self.fd.data is self.packet.packet)
+        self.assertTrue(self.fd.target is self.packet.source)
 
     def testSendReplyPacket(self):
         self.host.SendReplyPacket(self.fd, self.packet)
-        self.failUnless(self.fd.data is self.packet.replypacket)
-        self.failUnless(self.fd.target is self.packet.source)
+        self.assertTrue(self.fd.data is self.packet.replypacket)
+        self.assertTrue(self.fd.target is self.packet.source)

--- a/tests/testProxy.py
+++ b/tests/testProxy.py
@@ -30,7 +30,7 @@ class SocketTests(unittest.TestCase):
     def testProxyFd(self):
         self.proxy._poll = MockPoll()
         self.proxy._PrepareSockets()
-        self.failUnless(isinstance(self.proxy._proxyfd, MockSocket))
+        self.assertTrue(isinstance(self.proxy._proxyfd, MockSocket))
         self.assertEqual(list(self.proxy._fdmap.keys()), [1])
         self.assertEqual(self.proxy._poll.registry,
                 {1: select.POLLIN | select.POLLPRI | select.POLLERR})
@@ -50,7 +50,7 @@ class ProxyPacketHandlingTests(unittest.TestCase):
         try:
             self.proxy._HandleProxyPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('unknown host' in str(e))
+            self.assertTrue('unknown host' in str(e))
         else:
             self.fail()
 
@@ -63,7 +63,7 @@ class ProxyPacketHandlingTests(unittest.TestCase):
         try:
             self.proxy._HandleProxyPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('non-response' in str(e))
+            self.assertTrue('non-response' in str(e))
         else:
             self.fail()
 

--- a/tests/testServer.py
+++ b/tests/testServer.py
@@ -110,10 +110,10 @@ class SocketTests(unittest.TestCase):
         fd = MockFd()
         fd.source = object()
         pkt = self.server._GrabPacket(gen, fd)
-        self.failUnless(isinstance(pkt, TrivialObject))
-        self.failUnless(pkt.fd is fd)
-        self.failUnless(pkt.source is fd.source)
-        self.failUnless(pkt.data is fd.data)
+        self.assertTrue(isinstance(pkt, TrivialObject))
+        self.assertTrue(pkt.fd is fd)
+        self.assertTrue(pkt.source is fd.source)
+        self.assertTrue(pkt.data is fd.data)
 
     def testPrepareSocketNoFds(self):
         self.server._poll = MockPoll()
@@ -160,7 +160,7 @@ class AuthPacketHandlingTests(unittest.TestCase):
         try:
             self.server._HandleAuthPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('unknown host' in str(e))
+            self.assertTrue('unknown host' in str(e))
         else:
             self.fail()
 
@@ -169,7 +169,7 @@ class AuthPacketHandlingTests(unittest.TestCase):
         try:
             self.server._HandleAuthPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('port' in str(e))
+            self.assertTrue('port' in str(e))
         else:
             self.fail()
 
@@ -180,7 +180,7 @@ class AuthPacketHandlingTests(unittest.TestCase):
         Server.HandleAuthPacket = HandleAuthPacket
 
         self.server._HandleAuthPacket(self.packet)
-        self.failUnless(self.server.handled is self.packet)
+        self.assertTrue(self.server.handled is self.packet)
 
         Server.HandleAuthPacket = hap
 
@@ -199,7 +199,7 @@ class AcctPacketHandlingTests(unittest.TestCase):
         try:
             self.server._HandleAcctPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('unknown host' in str(e))
+            self.assertTrue('unknown host' in str(e))
         else:
             self.fail()
 
@@ -208,7 +208,7 @@ class AcctPacketHandlingTests(unittest.TestCase):
         try:
             self.server._HandleAcctPacket(self.packet)
         except ServerPacketError as e:
-            self.failUnless('port' in str(e))
+            self.assertTrue('port' in str(e))
         else:
             self.fail()
 
@@ -219,7 +219,7 @@ class AcctPacketHandlingTests(unittest.TestCase):
         Server.HandleAcctPacket = HandleAcctPacket
 
         self.server._HandleAcctPacket(self.packet)
-        self.failUnless(self.server.handled is self.packet)
+        self.assertTrue(self.server.handled is self.packet)
 
         Server.HandleAcctPacket = hap
 
@@ -242,8 +242,8 @@ class OtherTests(unittest.TestCase):
 
         reply = self.server.CreateReplyPacket(TrivialPacket(),
                 one='one', two='two')
-        self.failUnless(isinstance(reply, TrivialObject))
-        self.failUnless(reply.source is TrivialPacket.source)
+        self.assertTrue(isinstance(reply, TrivialObject))
+        self.assertTrue(reply.source is TrivialPacket.source)
         self.assertEqual(reply.kw, dict(one='one', two='two'))
 
     def testAuthProcessInput(self):
@@ -285,8 +285,8 @@ class ServerRunTests(unittest.TestCase):
         MockClassMethod(Server, '_PrepareSockets')
         self.assertRaises(MockFinished, self.server.Run)
         self.assertEqual(self.server.called, [('_PrepareSockets', (), {})])
-        self.failUnless(isinstance(self.server._fdmap, dict))
-        self.failUnless(isinstance(self.server._poll, MockPoll))
+        self.assertTrue(isinstance(self.server._fdmap, dict))
+        self.assertTrue(isinstance(self.server._poll, MockPoll))
 
     def testRunIgnoresPollErrors(self):
         self.server.authfds = [MockFd()]


### PR DESCRIPTION
The aliases were deprecated and removed in Python 3.11 . The recommended aliases are present in Python 2 too. Hence the PR is backwards compatible.

Ref : https://github.com/python/cpython/pull/28268

assertEquals -> assertEqual
failIf -> assertFalse
failUnless -> assertTrue

Fixes https://github.com/pyradius/pyrad/issues/165