### PR TITLE
Add salt decryption of encrypted attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ pyrad.egg-info/
 *.pyc
 *__pycache__
 *.egg/
+
+#virtual environments
+.env
+env
+.venv
+venv

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -241,6 +241,11 @@ class Packet(OrderedDict):
                       **attributes)
 
     def _DecodeValue(self, attr, value):
+
+        if attr.encrypt == 2:
+            #salt decrypt attribute
+            value = self.SaltDecrypt(value)
+
         if attr.values.HasBackward(value):
             return attr.values.GetBackward(value)
         else:
@@ -574,11 +579,29 @@ class Packet(OrderedDict):
 
             packet = packet[attrlen:]
 
+
+    def _salt_en_decrypt(self, data, salt):
+        result = b''
+        last = self.authenticator + salt
+        while data:
+            hash = md5_constructor(self.secret + last).digest()
+            if six.PY3:
+                for i in range(16):
+                    result += bytes((hash[i] ^ data[i],))
+            else:
+                for i in range(16):
+                    result += chr(ord(hash[i]) ^ ord(data[i]))
+
+            last = result[-16:]
+            data = data[16:]
+        return result
+
+
     def SaltCrypt(self, value):
-        """Salt Encryption
+        """SaltEncrypt
 
         :param value:    plaintext value
-        :type password:  unicode string
+        :type:           unicode string
         :return:         obfuscated version of the value
         :rtype:          binary string
         """
@@ -590,6 +613,7 @@ class Packet(OrderedDict):
             # self.authenticator = self.CreateAuthenticator()
             self.authenticator = 16 * six.b('\x00')
 
+        #create salt
         random_value = 32768 + random_generator.randrange(0, 32767)
         if six.PY3:
             salt_raw = struct.pack('!H', random_value )
@@ -598,27 +622,35 @@ class Packet(OrderedDict):
             salt = struct.pack('!H', random_value )
             salt = chr(ord(salt[0]) | 1 << 7)+salt[1]
 
-        result = six.b(salt)
-
+        #length prefixing
         length = struct.pack("B", len(value))
-        buf = length + value
-        if len(buf) % 16 != 0:
-            buf += six.b('\x00') * (16 - (len(buf) % 16))
+        value = length + value
 
-        last = self.authenticator + six.b(salt)
-        while buf:
-            hash = md5_constructor(self.secret + last).digest()
-            if six.PY3:
-                for i in range(16):
-                    result += bytes((hash[i] ^ buf[i],))
-            else:
-                for i in range(16):
-                    result += chr(ord(hash[i]) ^ ord(buf[i]))
+        #zero padding
+        if len(value) % 16 != 0:
+            value += six.b('\x00') * (16 - (len(value) % 16))
 
-            last = result[-16:]
-            buf = buf[16:]
+        return six.b(salt) + self._salt_en_decrypt(value, six.b(salt))
 
-        return result
+    def SaltDecrypt(self, value):
+        """ SaltDecrypt
+
+        :param value:   encrypted value including salt
+        :type:          binary string
+        :return:        decrypted plaintext string
+        :rtype:         unicode string
+        """
+        #extract salt
+        salt = value[:2]
+
+        #decrypt
+        value = self._salt_en_decrypt(value[2:], salt)
+
+        #remove padding
+        length = value[0]
+        value = value[1:length+1]
+
+        return value
 
 
 class AuthPacket(Packet):

--- a/tests/data/full
+++ b/tests/data/full
@@ -16,6 +16,10 @@ ATTRIBUTE  Test-Tlv-Int   4.2   integer
 
 ATTRIBUTE  Message-Authenticator 80  octets
 
+ATTRIBUTE Test-Encrypted-String   5   string      encrypt=2
+ATTRIBUTE Test-Encrypted-Octets   6   octets      encrypt=2
+ATTRIBUTE Test-Encrypted-Integer  7   integer     encrypt=2
+
 VENDOR Simplon 16
 
 

--- a/tests/testPacket.py
+++ b/tests/testPacket.py
@@ -166,6 +166,13 @@ class PacketTests(unittest.TestCase):
         self.packet[(16, 1)] = marker
         self.assertTrue(self.packet[(16, 1)] is marker)
 
+    def testEncryptedAttributes(self):
+        self.packet['Test-Encrypted-String'] = 'dummy'
+        self.assertEqual(self.packet['Test-Encrypted-String'], ['dummy'])
+        
+        self.packet['Test-Encrypted-Integer'] = 10
+        self.assertEqual(self.packet['Test-Encrypted-Integer'], [10])
+
     def testHasKey(self):
         self.assertEqual(self.packet.has_key('Test-String'), False)
         self.assertEqual('Test-String' in self.packet, False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the ability to salt decrypt encrypted attributes. Therefore the `pyrad.packet.Packet` class got a new function following the example of `pyrad.packet.Packet.SaltCrypt`. In addition to that the internal `_DecodeValue` function got changed and now directly decrypts the attribute whenever a user tries to access an attribute value and the attribute has `encrypt=2`.

## Motivation and Context
I just stumbled over an issue working with encrypted integer attributes which is basically reproducible by following code snippet.
```python
from pyrad import dictionary, packet

attribute_dict = dictionary.Dictionary()
attribute_dict.attributes["Encrypted-Attribute"] = \
  dictionary.Attribute("Encrypted-Attribute", 1, 'integer', encrypt=2)

pkg = packet.Packet(code=1, secret=b'secret', dict=attribute_dict,
  Encrypted_Attribute=1
)
print(pkg['Encrypted-Attribute'])
```
Output:
```bash
Traceback (most recent call last):
  File "[...]/demo.py", line 9, in <module>
    print(pkg['Encrypted-Attribute'])
  File "[...]/lib/python3.9/site-packages/pyrad/packet.py", line 343, in __getitem__
    res.append(self._DecodeValue(attr, v))
  File "[...]/lib/python3.9/site-packages/pyrad/packet.py", line 247, in _DecodeValue
    return tools.DecodeAttr(attr.type, value)
  File "[...]/lib/python3.9/site-packages/pyrad/tools.py", line 216, in DecodeAttr
    return DecodeInteger(value)
  File "[...]/lib/python3.9/site-packages/pyrad/tools.py", line 172, in DecodeInteger
    return (struct.unpack(format, num))[0]
struct.error: unpack requires a buffer of 4 bytes
```

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
A added a new unit tests for testing encrypted attributes:
```python
def testEncryptedAttributes(self):
        self.packet['Test-Encrypted-String'] = 'dummy'
        self.assertEqual(self.packet['Test-Encrypted-String'], ['dummy'])
        
        self.packet['Test-Encrypted-Integer'] = 10
        self.assertEqual(self.packet['Test-Encrypted-Integer'], [10])
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  (What changes is that values now get decrypted automatically, no API change but a behaviour change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.