### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyrad/host.py
+++ b/pyrad/host.py
@@ -57,7 +57,7 @@ class Host(object):
 
     def CreateAcctPacket(self, **args):
         """Create a new accounting RADIUS packet.
-        This utility function creates a new accouting RADIUS packet
+        This utility function creates a new accounting RADIUS packet
         which can be used to communicate with the RADIUS server this
         client talks to. This is initializing the new packet with the
         dictionary and secret used for the client.

--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -60,7 +60,7 @@ class Packet(OrderedDict):
     attributes the value will always be a sequence. pyrad makes sure
     to preserve the ordering when encoding and decoding packets.
 
-    There are two ways to use the map intereface: if attribute
+    There are two ways to use the map interface: if attribute
     names are used pyrad take care of en-/decoding data. If
     the attribute type number (or a vendor ID/attribute type
     tuple for vendor attributes) is used you work with the


### PR DESCRIPTION
There are small typos in:
- pyrad/host.py
- pyrad/packet.py

Fixes:
- Should read `interface` rather than `intereface`.
- Should read `accounting` rather than `accouting`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md