### PR TITLE
Fix missing get addr info without services info

### DIFF
--- a/pyrad/server.py
+++ b/pyrad/server.py
@@ -114,7 +114,7 @@ class Server(host.Host):
         """
         results = set()
         try:
-            tmp = socket.getaddrinfo(addr, 'www')
+            tmp = socket.getaddrinfo(addr, '80')
         except socket.gaierror:
             return []
 


### PR DESCRIPTION
If /etc/services is miss linux does not know what is www