### PR TITLE
Fix KeyError in _HandleCoaPacket for 0.0.0.0 host

### DIFF
--- a/pyrad/server.py
+++ b/pyrad/server.py
@@ -247,7 +247,6 @@ class Server(host.Host):
         :type  pkt: Packet class instance
         """
         self._AddSecret(pkt)
-        pkt.secret = self.hosts[pkt.source[0]].secret
         if pkt.code == packet.CoARequest:
             self.HandleCoaPacket(pkt)
         elif pkt.code == packet.DisconnectRequest:


### PR DESCRIPTION
When defining a client host `0.0.0.0` for a CoA radius Server, then a KeyError will occur when handling a CoA packet.

    File ".../pyrad/server.py", line 250, in _HandleCoaPacket
        pkt.secret = self.hosts[pkt.source[0]].secret
                     ~~~~~~~~~~^^^^^^^^^^^^^^^
    KeyError: '172.16.0.100'

The reason seems to be that _AddSecret() was added at some point to support using `0.0.0.0` as a host, but the `pkt.secret = ...` assignment that it ought to replace was not removed.

This patch fixes the behavior by removing the stale assignment.