### PR TITLE
pyproject.toml: support poetry-core 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = [
 ]
 
 [tool.poetry.urls]
-repository = "https://github.com/pyradius/pyrad"
+Repository = "https://github.com/pyradius/pyrad"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
This key is case-sensitive in poetry-core 2.x.
Did not check whether it still works with poetry 1.x.