### PR TITLE
doc: fix build error due to outdated intersphinx mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,4 +155,4 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
Newest versions of Sphinx changed the format for the `intersphinx_mapping` option: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping Now requiring a tuple. Fix this so docs can be built again.