### PR TITLE
Fix salt decryption past the first block (MS-MPPE keys, long Tunnel-Password)

### DIFF
--- a/pyrad/packet.py
+++ b/pyrad/packet.py
@@ -570,7 +570,7 @@ class Packet(OrderedDict):
 
             packet = packet[attrlen:]
 
-    def _salt_en_decrypt(self, data, salt):
+    def _salt_en_decrypt(self, data, salt, encrypt=True):
         result = b''
         if self.request_authenticator is not None:
             last = self.request_authenticator + salt
@@ -578,10 +578,15 @@ class Packet(OrderedDict):
             last = self.authenticator + salt
         while data:
             hash = hashlib.md5(self.secret + last).digest()
+            block = b''
             for i in range(16):
-                result += bytes((hash[i] ^ data[i],))
+                block += bytes((hash[i] ^ data[i],))
+            result += block
 
-            last = result[-16:]
+            # RFC 2868 3.5: each block chains on the ciphertext block, which is the
+            # output when encrypting but the input when decrypting. Chaining on the
+            # output unconditionally corrupted every block past the first on decrypt.
+            last = block if encrypt else data[:16]
             data = data[16:]
         return result
 
@@ -627,7 +632,7 @@ class Packet(OrderedDict):
         salt = value[:2]
 
         # decrypt
-        value = self._salt_en_decrypt(value[2:], salt)
+        value = self._salt_en_decrypt(value[2:], salt, encrypt=False)
 
         # remove padding
         length = value[0]

--- a/pyrad/tests/test_packet.py
+++ b/pyrad/tests/test_packet.py
@@ -165,6 +165,16 @@ class PacketTests(unittest.TestCase):
         self.packet['Test-Encrypted-Integer'] = 10
         self.assertEqual(self.packet['Test-Encrypted-Integer'], [10])
 
+    def testSaltCryptRoundTrip(self):
+        # SaltDecrypt must invert SaltCrypt past the first 16-byte block. The
+        # chaining used the ciphertext when encrypting but the plaintext when
+        # decrypting, so anything over one block (MS-MPPE keys, long
+        # Tunnel-Password) came back corrupt after byte 15.
+        self.packet.request_authenticator = self.packet.authenticator
+        for value in (b'x', b'0123456789abcde', bytes(range(32)), bytes(range(100))):
+            self.assertEqual(
+                self.packet.SaltDecrypt(self.packet.SaltCrypt(value)), value)
+
     def testHasKey(self):
         self.assertEqual(self.packet.has_key('Test-String'), False)
         self.assertEqual('Test-String' in self.packet, False)


### PR DESCRIPTION
`_salt_en_decrypt` chains each 16-byte block on the previous block of its own
output. That is correct when encrypting (the output is the ciphertext, which is
what RFC 2868 section 3.5 chains on), but wrong when decrypting: there the output
is the plaintext, so every block after the first is masked with the wrong MD5 and
comes back garbage. The first block always survives because it is keyed on the
request authenticator with no chaining.

Anything longer than 16 bytes is affected: MS-MPPE-Send-Key / MS-MPPE-Recv-Key (a
32-byte key is 48 bytes once length-prefixed and padded) and any Tunnel-Password
over one block. A proxy that decrypts MPPE keys from an upstream and re-encrypts
them hands the NAS a corrupt PMK, which shows up as a 4-way handshake / PMK
mismatch (the symptom in #166).

Fix: chain on the ciphertext block in both directions. Encrypt still chains on the
output block; decrypt now chains on the input block. `SaltDecrypt` passes
`encrypt=False`; the default keeps `SaltCrypt` and any external callers unchanged.

Verification:

* Matches RFC 2868 section 3.5 (and RFC 2548 section 2.4.2, identical
  construction): `b(i) = MD5(S + c(i-1))` chains on the previous ciphertext block,
  i.e. the input block when decrypting.
* Cross-checked against an independent implementation: the fixed code and a
  standalone RFC 2868 codec each decrypt the other's ciphertext, both directions,
  for 1/16/17/32/48/100-byte values.
* `pytest pyrad/tests/` passes (203 existing + 1 new round-trip test).

Likely fixes #166.
